### PR TITLE
2025-update

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,20 +1,50 @@
+import subprocess
+import atexit
+import platform
 from playsound import playsound
-
 from selenium_driver import SeleniumDriver
-from user_inputs import URL, CPF, SECTIONS_WITH_MEMBERSHIP_DISCOUNT, NUMBER_OF_GUESTS, USERNAME, PASSWORD, IS_SCHEDULED, \
+from user_inputs import URL, CPF, SECTIONS_WITH_MEMBERSHIP_DISCOUNT, MEMBERSHIP_HOLDER, NUMBER_OF_GUESTS, \
+    GENERAL_AVAILABLE_TICKET, HALF_PRICE_TICKET, USERNAME, PASSWORD, IS_SCHEDULED, \
     SCHEDULED_TIMESTAMP, SECTIONS_WITHOUT_DISCOUNT
+
+# Determine the operating system
+os_name = platform.system()
+
+# Start the appropriate command to prevent the system from sleeping
+if os_name == 'Darwin':  # macOS
+    caffeinate_process = subprocess.Popen(['caffeinate'])
+elif os_name == 'Linux':
+    caffeinate_process = subprocess.Popen(['xdg-screensaver', 'suspend', ':0'])
+elif os_name == 'Windows':
+    subprocess.run(['powercfg', '/change', 'monitor-timeout-ac', '0'])
+    subprocess.run(['powercfg', '/change', 'monitor-timeout-dc', '0'])
+    caffeinate_process = None
+else:
+    caffeinate_process = None
+
+
+# Ensure the command is terminated or settings are restored when the script ends
+def cleanup():
+    if os_name == 'Darwin' or os_name == 'Linux':
+        caffeinate_process.terminate()
+    elif os_name == 'Windows':
+        subprocess.run(['powercfg', '/change', 'monitor-timeout-ac', '20'])
+        subprocess.run(['powercfg', '/change', 'monitor-timeout-dc', '10'])
+
 
 driver = SeleniumDriver(URL, IS_SCHEDULED, SCHEDULED_TIMESTAMP)
 
 success = False
-section_index = 0
 
 while not success:
     driver.accept_cookies()
 
-    cpf_success = driver.input_cpf(CPF)
-    if not cpf_success:
-        continue  # reiniciar loop
+    driver.driver.execute_script("document.body.style.zoom='50%'")
+
+    if MEMBERSHIP_HOLDER:
+        cpf_success = driver.input_cpf(CPF)
+        if not cpf_success:
+            continue  # reiniciar loop
 
     target_section_found = driver.define_target_section(
         desired_sections=SECTIONS_WITH_MEMBERSHIP_DISCOUNT + SECTIONS_WITHOUT_DISCOUNT)
@@ -29,10 +59,13 @@ while not success:
     if not target_section_tab_was_found:
         continue
 
-    tickets_were_added = driver.add_tickets_to_cart(NUMBER_OF_GUESTS, is_without_discount)
+    tickets_were_added = driver.add_tickets_to_cart(MEMBERSHIP_HOLDER, NUMBER_OF_GUESTS, is_without_discount,
+                                                    GENERAL_AVAILABLE_TICKET, HALF_PRICE_TICKET)
     if not tickets_were_added:
         continue
 
     success = driver.log_in(USERNAME, PASSWORD)
+    driver.driver.execute_script("document.body.style.zoom='100%'")
 
+atexit.register(cleanup)
 playsound('success_song.mp3')

--- a/user_inputs.py
+++ b/user_inputs.py
@@ -1,27 +1,32 @@
 from datetime import datetime
 
 # url da página de compra do jogo (tem que ser aquela que começa com "cart.totacesso")
-URL = "https://cart.spfcticket.net/saopaulofcxinternacional_22_09"
+URL = "https://cart.spfcticket.net/saopaulofcxnovorizontino_quartas_de_final_2025"
 
 # lista com os setores em ordem de preferência
-SECTIONS_WITH_MEMBERSHIP_DISCOUNT = ["ARQUIBANCADA LESTE LACTA", "ARQUIBANCADA OESTE OURO BRANCO",
+SECTIONS_WITH_MEMBERSHIP_DISCOUNT = ["ARQUIBANCADA LESTE LACTA",
+                                     "ARQUIBANCADA OESTE OURO BRANCO"
                                      "ARQUIBANCADA NORTE OURO BRANCO", "ARQUIBANCADA SUL DIAMANTE NEGRO",
                                      "CADEIRA SUPERIOR NORTE OREO"]
 
-SECTIONS_WITHOUT_DISCOUNT = ["ARQUIBANCADA NORTE OURO BRANCO", "ARQUIBANCADA SUL DIAMANTE NEGRO",
-                             "CADEIRA SUPERIOR NORTE OREO",
-                             "CAD. SUP. SUL DIAMANTE NEGRO", "CAD. ESP. OESTE OURO BRANCO"]
+SECTIONS_WITHOUT_DISCOUNT =  ["ARQUIBANCADA NORTE OURO BRANCO", "ARQUIBANCADA SUL DIAMANTE NEGRO",
+ "CADEIRA SUPERIOR NORTE OREO",
+ "CAD. SUP. SUL DIAMANTE NEGRO", "CAD. ESP. OESTE OURO BRANCO"]
 
 # credenciais
 USERNAME: str =
 PASSWORD: str =
 
 # cpf do sócio
-CPF: int =
+CPF: str =
 
-# número de convidados
-NUMBER_OF_GUESTS = 2
+# quantidade de ingressos
+MEMBERSHIP_HOLDER: bool = True  # ingresso do titular (0 ou 1)
+NUMBER_OF_GUESTS = 1  # convidado
+
+GENERAL_AVAILABLE_TICKET = 0  # ingresso inteiro venda geral
+HALF_PRICE_TICKET: bool = False  # meia entrada venda geral
 
 # se quiser começar em um determinado horário
 IS_SCHEDULED = True
-SCHEDULED_TIMESTAMP = datetime(2023, 8, 28, 21, 59)
+SCHEDULED_TIMESTAMP = datetime(2025, 2, 27, 18, 00)


### PR DESCRIPTION
# ajustes para 2025:
- diminuir zoom para que todos os tipos de ingresso estejam visíveis. Tive um problema que o ingresso de convidado não estava sendo adicionado. Notei que era porque o botão não estava visível devido ao tamanho da minha tela (11 polegadas)
- manter o computador acordado. Quando o computador entra em modo de repouso, a contagem de tempo para o início das atividades no horário agendado fica cagada
- inclusão da possibilidade de comprar ingressos de ampla concorrência. Exemplo: meu plano tem direito ao ingresso do titular + 1 convidado. Para comprar ingressos além desses dois, devo comprar os de ampla concorrência